### PR TITLE
Add package.json for npmjs.org registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cordova-plugin-startapp",
+  "version": "0.0.4",
+  "description": "Phonegap 3 plugin for check or launch other application in android device.",
+  "cordova": {
+    "id": "com.lampa.startapp",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kraihn/com.lampa.startapp.git"
+  },
+  "keywords": [
+    "cordova",
+    "startapp",
+    "lampa",
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kraihn/com.lampa.startapp/issues"
+  },
+  "homepage": "https://github.com/kraihn/com.lampa.startapp#readme"
+}


### PR DESCRIPTION
Hi, could you please merge this pull request and publish your plugin to npmjs.org? The Cordova plugin registry will be shutting down soon, and I use your package for a few projects. Without moving it over I'll need to find another alternative, thanks.