### PR TITLE
Fixed setPackage call for LaunchIntent

### DIFF
--- a/src/android/startApp.java
+++ b/src/android/startApp.java
@@ -81,15 +81,14 @@ public class startApp extends CordovaPlugin {
 			if (args.get(0) instanceof JSONObject) {
 				params = args.getJSONObject(0);
 				
+        			LaunchIntent = new Intent();
+
 				/**
 				 * set package
 				 * http://developer.android.com/reference/android/content/Intent.html#setPackage(java.lang.String)
 				 */
 				if(params.has("package")) {
-					LaunchIntent = cordova.getActivity().getPackageManager().getLaunchIntentForPackage(params.getString("package"));
-				}
-				else {
-					LaunchIntent = new Intent();	
+					LaunchIntent.setPackage(params.getString("package"));
 				}
 				
 				/**


### PR DESCRIPTION
I tested the startapp plugin for Android, but it never worked properly with Instagram (opening a user profile). The problem was that it opens Instagram in Android, but never opens the user's profile page. I discovered that by making this change, it fixes the issue.
```
        Intent insta = new Intent(, uri);
        insta.setAction(Intent.ACTION_VIEW);
        insta.setData(Uri.parse("http://instagram.com/_u/someUsername"));
        insta.setPackage("com.instagram.android");
        cordova.getActivity().startActivity(insta);
```