### PR TITLE
fixes a typo

### DIFF
--- a/src/android/startApp.java
+++ b/src/android/startApp.java
@@ -164,7 +164,7 @@ public class startApp extends Assets {
 					LaunchIntent = new Intent();
 					if(params.has("intent")) {
 						ComponentName ci = new ComponentName(cordova.getActivity().getPackageName(), params.getString("intent"));
-						it.setComponent(ci);
+						LaunchIntent.setComponent(ci);
 					}
 				}
         		


### PR DESCRIPTION
Last commit had a typo in it, so now the builds would fail with and error where `symbol it is not defined`. See #129 
