### PR TITLE
Match Double type in string extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ var sApp = startApp.set({} params [, {} extras]);
 | Param | Description | Default | Values |
 | --- | --- | --- | --- |
 | noParse | Disable find action and category in Intent package | false | Boolean |
+| matchDoubleInSting | Match Double type in string extras (usefull for coordinates, prices etc.) | false | Boolean |
 | intent | [Intent(String action)](https://developer.android.com/reference/android/content/Intent.html#Intent%28java.lang.String%29) | null | String |
 | application | [Intent (Context packageContext)](https://developer.android.com/reference/android/content/Intent.html#Intent%28android.content.Context,%20java.lang.Class%3C?%3E%29) | null | String |
 | action | [Intent setAction](http://developer.android.com/reference/android/content/Intent.html#setAction(java.lang.String)) | null | String ||

--- a/src/android/Assets.java
+++ b/src/android/Assets.java
@@ -61,4 +61,8 @@ public class Assets extends CordovaPlugin {
 
         return field.getInt(null);
     }
+
+    protected boolean matchDoubleInSting(String str) {
+        return (Pattern.matches("([0-9]*)\\.([0-9]*)", str));
+    }
 }

--- a/src/android/startApp.java
+++ b/src/android/startApp.java
@@ -250,7 +250,9 @@ public class startApp extends Assets {
 							LaunchIntent.putExtra(parseExtraName(key), extra.getInt(key));
 						}
 
-						if(value instanceof String) {
+						if(params.has("matchDoubleInSting") && matchDoubleInSting(extra.getString(key))) {
+                            LaunchIntent.putExtra(parseExtraName(key), extra.getDouble(key));
+                        } else if(value instanceof String) {
 							LaunchIntent.putExtra(parseExtraName(key), extra.getString(key));
 						}
 


### PR DESCRIPTION
Adds support to send numbers with floating point as string from JS and interpret it as Double type in Java. Useful to process coordinates, prices etc. Especially it helps when zeros are after dot: 200.00.