### PR TITLE
Refactor iOS implementation; change deprecated function call

### DIFF
--- a/src/ios/startApp.m
+++ b/src/ios/startApp.m
@@ -4,55 +4,49 @@
 @implementation startApp
 
 - (void)check:(CDVInvokedUrlCommand*)command {
-    
     CDVPluginResult* pluginResult = nil;
-    
+
     NSString* scheme = [command.arguments objectAtIndex:0];
-    
+
     if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
     }
     else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:(false)];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:NO];
     }
-    
+
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    
 }
 
 - (void)start:(CDVInvokedUrlCommand*)command {
-    
-    CDVPluginResult* pluginResult = nil;
-    
     NSString* scheme = [command.arguments objectAtIndex:0];
-    
-    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
-		[[UIApplication sharedApplication] openURL:[NSURL URLWithString:scheme]];
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
+    NSURL *url = [NSURL URLWithString:scheme];
+
+    if ([[UIApplication sharedApplication] canOpenURL:url]) {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+            CDVPluginResult *result = success ?
+                [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES] :
+                [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:NO];
+
+            [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+        }];
     }
     else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:(false)];
+        CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:NO];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
     }
-    
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    
 }
 
 - (void)go:(CDVInvokedUrlCommand*)command {
-    
-    CDVPluginResult* pluginResult = nil;
-    
     NSString* scheme = [command.arguments objectAtIndex:0];
-    
-    if ([[UIApplication sharedApplication] openURL:[NSURL URLWithString:scheme]]) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
-    }
-    else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:(false)];
-    }
-    
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    
+    NSURL *url = [NSURL URLWithString:scheme];
+
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+        CDVPluginResult *result = success ?
+            [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES] :
+            [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:NO];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }];
 }
 
 @end


### PR DESCRIPTION
Replaces deprecated openURL function with a new recommended one. Also refactors the whole iOS implementation to be more concise.
Most of the work was done with AI tools, so it should be looked at by someone proficient in Objective-C. But it was tested on production app and it works.